### PR TITLE
Update user bracket URLs for 2019

### DIFF
--- a/templates/macros.tpl
+++ b/templates/macros.tpl
@@ -6,7 +6,7 @@
 {% macro user_link(username, bracket_id, year) -%}
   <a
       name="{{ username | e }}"
-      href="http://games.espn.go.com/tournament-challenge-bracket/{{ year }}/en/entry?entryID={{ bracket_id| e }}"
+      href="http://fantasy.espn.com/tournament-challenge-bracket/{{ year  }}/en/entry?entryID={{ bracket_id| e }}"
       >{{ username | e }}</a>
   (<a href="http://www.reddit.com/u/{{ username | e }}">reddit</a>)
 {%- endmacro %}


### PR DESCRIPTION
Bracket links on the leaderboard/subreddit pages were still using the old link format, preventing users from viewing brackets. 